### PR TITLE
Now the adapter fully implements generator contract by propagating future's exceptions

### DIFF
--- a/toasyncio/gen.py
+++ b/toasyncio/gen.py
@@ -28,17 +28,14 @@ def coroutine(func):
                 if not current_future:
                     current_future = next(result)
 
-                if isinstance(current_future, (tornado.gen.Future, list)):                                                             
-                    pass                                                                                                               
-    
-                elif isinstance(current_future, types.GeneratorType):                                                                  
-                    task = asyncio.tasks.Task(current_future, loop=io_loop.asyncio_loop)                                               
-                    current_future = tornado.platform.asyncio.to_tornado_future(task)                                                  
-        
-                elif isinstance(current_future, asyncio.Future):                                                                       
-                    current_future = tornado.platform.asyncio.to_tornado_future(current_future)                                        
+                if isinstance(current_future, types.GeneratorType):
+                    task = asyncio.tasks.Task(current_future, loop=io_loop.asyncio_loop)
+                    current_future = tornado.platform.asyncio.to_tornado_future(task)
 
-                else:
+                elif isinstance(current_future, asyncio.Future):
+                    current_future = tornado.platform.asyncio.to_tornado_future(current_future)
+
+                elif not isinstance(current_future, (tornado.gen.Future, list)):
                     result.throw(TypeError, 'Expected generator or future: %s' % type(current_future),
                                  result.gi_frame.f_trace)
 

--- a/toasyncio/gen.py
+++ b/toasyncio/gen.py
@@ -28,21 +28,27 @@ def coroutine(func):
                 if not current_future:
                     current_future = next(result)
 
-                if isinstance(current_future, (tornado.gen.Future, list)):
-                    current_result = yield current_future
-
-                elif isinstance(current_future, types.GeneratorType):
-                    task = asyncio.tasks.Task(current_future, loop=io_loop.asyncio_loop)
-                    current_result = yield tornado.platform.asyncio.to_tornado_future(task)
-
-                elif isinstance(current_future, asyncio.Future):
-                    current_result = yield tornado.platform.asyncio.to_tornado_future(current_future)
+                if isinstance(current_future, (tornado.gen.Future, list)):                                                             
+                    pass                                                                                                               
+    
+                elif isinstance(current_future, types.GeneratorType):                                                                  
+                    task = asyncio.tasks.Task(current_future, loop=io_loop.asyncio_loop)                                               
+                    current_future = tornado.platform.asyncio.to_tornado_future(task)                                                  
+        
+                elif isinstance(current_future, asyncio.Future):                                                                       
+                    current_future = tornado.platform.asyncio.to_tornado_future(current_future)                                        
 
                 else:
                     result.throw(TypeError, 'Expected generator or future: %s' % type(current_future),
                                  result.gi_frame.f_trace)
 
-                current_future = result.send(current_result)
+                current_result = None
+                try:
+                    current_result = yield current_future
+                except Exception as ex:
+                    current_future = result.throw(type(ex), ex)
+                else:
+                    current_future = result.send(current_result)
 
         except StopIteration as e:
             return e.value


### PR DESCRIPTION
After this fix web applications doesn't hang after an exception in async db layer.
